### PR TITLE
Adds mb4 character replacement in title when creating web resource item

### DIFF
--- a/classes/class.ilElectronicCourseReserveDigitizedMediaImporter.php
+++ b/classes/class.ilElectronicCourseReserveDigitizedMediaImporter.php
@@ -545,7 +545,7 @@ class ilElectronicCourseReserveDigitizedMediaImporter
         if (strlen($parsed_item->getItem()->getUrl()) > 0 &&
             $folder_ref_id != 0) {
 
-            $title = $parsed_item->getLabel();
+            $title = preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $parsed_item->getLabel());
             if(mb_strlen($title) > 127) {
                 $this->logger->warn(sprintf(
                     'Title for item %s is too long, it will be truncated to 127 characters.',


### PR DESCRIPTION
The web resource title may contain Unicode characters outside the Basic Multilingual Plane (UTF-8 MB4), which are not supported by the ILIAS database (limited to UTF-8 MB3). This hotfix removes such characters to ensure compatibility.